### PR TITLE
chore: add index.properties for toolset repository discovery

### DIFF
--- a/index.properties
+++ b/index.properties
@@ -1,0 +1,21 @@
+wanaku.toolsets=brazil,currency,development,fun,mexico,search,util,web
+
+wanaku.toolset.icon=🔧
+
+wanaku.description.brazil=Geographic, economic, and civic data tools for Brazil (IBGE, CEP, CNPJ, banks, holidays)
+wanaku.description.currency=Currency conversion tools
+wanaku.description.development=Developer utility tools (DNS, WHOIS, QR codes, public APIs, email verification)
+wanaku.description.fun=Fun and trivia tools (memes, useless facts, dog and cat facts)
+wanaku.description.mexico=Geographic data tools for Mexico (zip codes)
+wanaku.description.search=Web search tools (DuckDuckGo)
+wanaku.description.util=General-purpose utility tools (name prediction, fruits, breweries, barcodes)
+wanaku.description.web=Cloud service status tools (Digital Ocean)
+
+wanaku.toolset.brazil.icon=🇧🇷
+wanaku.toolset.currency.icon=💱
+wanaku.toolset.development.icon=💻
+wanaku.toolset.fun.icon=🎲
+wanaku.toolset.mexico.icon=🇲🇽
+wanaku.toolset.search.icon=🔍
+wanaku.toolset.util.icon=🧰
+wanaku.toolset.web.icon=🌐


### PR DESCRIPTION
## Summary

- Add `index.properties` file for toolset repository discovery by the Wanaku router
- Lists all 8 toolsets (brazil, currency, development, fun, mexico, search, util, web) with descriptions and emoji icons
- Follows the index format defined in wanaku-ai/wanaku#1040

## Test plan
- [ ] Verify `index.properties` is fetchable from the raw GitHub URL
- [ ] Browse this repository from a Wanaku instance using the Toolset Repositories UI tab