### PR TITLE
Add Nager.Date public holiday API to util toolset

### DIFF
--- a/toolsets/util.json
+++ b/toolsets/util.json
@@ -123,4 +123,107 @@
     },
     "required" : [ "countryCode" ]
   }
+}, {
+  "name" : "get-public-holidays",
+  "description" : "Get all public holidays for a given country and year",
+  "uri" : "https://date.nager.at/api/v3/PublicHolidays/{parameter.value('year')}/{parameter.value('countryCode')}",
+  "type" : "http",
+  "inputSchema" : {
+    "type" : "object",
+    "properties" : {
+      "year" : {
+        "type" : "string",
+        "description" : "The calendar year (e.g., 2026)"
+      },
+      "countryCode" : {
+        "type" : "string",
+        "description" : "The ISO 3166-1 alpha-2 country code (e.g., US, BR, DE, AT)"
+      }
+    },
+    "required" : [ "year", "countryCode" ]
+  }
+}, {
+  "name" : "get-next-public-holidays",
+  "description" : "Get upcoming public holidays for the next 365 days for a given country",
+  "uri" : "https://date.nager.at/api/v3/NextPublicHolidays/{parameter.value('countryCode')}",
+  "type" : "http",
+  "inputSchema" : {
+    "type" : "object",
+    "properties" : {
+      "countryCode" : {
+        "type" : "string",
+        "description" : "The ISO 3166-1 alpha-2 country code (e.g., US, BR, DE, AT)"
+      }
+    },
+    "required" : [ "countryCode" ]
+  }
+}, {
+  "name" : "get-next-public-holidays-worldwide",
+  "description" : "Get upcoming public holidays worldwide for the next 7 days",
+  "uri" : "https://date.nager.at/api/v3/NextPublicHolidaysWorldwide",
+  "type" : "http",
+  "inputSchema" : {
+    "type" : "object",
+    "properties" : { },
+    "required" : null
+  }
+}, {
+  "name" : "is-today-public-holiday",
+  "description" : "Check if today is a public holiday in a given country",
+  "uri" : "https://date.nager.at/api/v3/IsTodayPublicHoliday/{parameter.value('countryCode')}",
+  "type" : "http",
+  "inputSchema" : {
+    "type" : "object",
+    "properties" : {
+      "countryCode" : {
+        "type" : "string",
+        "description" : "The ISO 3166-1 alpha-2 country code (e.g., US, BR, DE, AT)"
+      }
+    },
+    "required" : [ "countryCode" ]
+  }
+}, {
+  "name" : "get-long-weekends",
+  "description" : "Get all long weekends for a given country and year",
+  "uri" : "https://date.nager.at/api/v3/LongWeekend/{parameter.value('year')}/{parameter.value('countryCode')}",
+  "type" : "http",
+  "inputSchema" : {
+    "type" : "object",
+    "properties" : {
+      "year" : {
+        "type" : "string",
+        "description" : "The calendar year (e.g., 2026)"
+      },
+      "countryCode" : {
+        "type" : "string",
+        "description" : "The ISO 3166-1 alpha-2 country code (e.g., US, BR, DE, AT)"
+      }
+    },
+    "required" : [ "year", "countryCode" ]
+  }
+}, {
+  "name" : "get-country-info",
+  "description" : "Get country info including common name, official name, region and borders",
+  "uri" : "https://date.nager.at/api/v3/CountryInfo/{parameter.value('countryCode')}",
+  "type" : "http",
+  "inputSchema" : {
+    "type" : "object",
+    "properties" : {
+      "countryCode" : {
+        "type" : "string",
+        "description" : "The ISO 3166-1 alpha-2 country code (e.g., US, BR, DE, AT)"
+      }
+    },
+    "required" : [ "countryCode" ]
+  }
+}, {
+  "name" : "get-available-countries",
+  "description" : "Get all available countries supported by the public holiday API",
+  "uri" : "https://date.nager.at/api/v3/AvailableCountries",
+  "type" : "http",
+  "inputSchema" : {
+    "type" : "object",
+    "properties" : { },
+    "required" : null
+  }
 } ]


### PR DESCRIPTION
## Summary
- Adds 7 tools from the [Nager.Date API](https://date.nager.at/api) to the util toolset
- Tools: get-public-holidays, get-next-public-holidays, get-next-public-holidays-worldwide, is-today-public-holiday, get-long-weekends, get-country-info, get-available-countries
- Free API, no authentication required, supports 100+ countries

## Test plan
- [ ] Load the util toolset and verify each new tool is listed
- [ ] Test `get-public-holidays` with year/country (e.g., 2026/US)
- [ ] Test `get-available-countries` returns the country list
- [ ] Test `is-today-public-holiday` with a known country code